### PR TITLE
Update build configuration for Java 11+ compatibility

### DIFF
--- a/Colossus/build.properties
+++ b/Colossus/build.properties
@@ -21,6 +21,6 @@ testresults.dir=${build.dir}/testresults
 build.javadoc.dir=${build.dir}/javadoc
   
 # settings
-source.level=1.7
-target.level=1.7
+source.level=11
+target.level=11
 boot.classpath=${env.JAVA_HOME}/jre/lib/rt.jar


### PR DESCRIPTION
This change updates the source and target levels from Java 1.7 to Java 11, enabling the project to build and run on modern Java versions (11-17+).

The game successfully builds and runs on Java 17 with only deprecation warnings. This update is essential for running on modern systems, particularly Apple Silicon Macs which require Java 11+ for native support.

Tested on:
- macOS 15.5 with Apple M4 processor
- OpenJDK 17.0.16 (Temurin)
- Game launches and plays normally

🤖 Generated with [Claude Code](https://claude.ai/code)